### PR TITLE
When changing external sync path, reset extensions path

### DIFF
--- a/src/cs.ts
+++ b/src/cs.ts
@@ -109,7 +109,6 @@ export class CodeSync {
         csSettings.externalPath = extPath;
         this.codeSyncDir = extPath;
         this.Settings.Settings = csSettings;
-        this.Settings.ExternalExtensionsPath = path.join(this.codeSyncDir, EXTENSIONS);
         this.Settings.save();
     }
 

--- a/src/cs.ts
+++ b/src/cs.ts
@@ -109,6 +109,7 @@ export class CodeSync {
         csSettings.externalPath = extPath;
         this.codeSyncDir = extPath;
         this.Settings.Settings = csSettings;
+        this.Settings.ExternalExtensionsPath = path.join(this.codeSyncDir, EXTENSIONS);
         this.Settings.save();
     }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -109,6 +109,7 @@ export class CodeSyncSettings {
     }
 
     save() {
+        this.ExternalExtensionsPath = path.join(this.settings.externalPath, cs.EXTENSIONS);
         fs.writeFileSync(this.internalPath, JSON.stringify(this.settings, null, 4));
     }
 


### PR DESCRIPTION
If you change the sync path and don't exit, the extensions are being saved to the old location.  This will reset the external extensions path when the sync path is changed.